### PR TITLE
Improve implicit destination

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -14,16 +14,5 @@ jobs:
       - name: Run StoryFlow tests
         run: |
           set -eo pipefail
-          xcodebuild test -scheme StoryFlow -destination "platform=iOS Simulator,name=iPhone 11" | xcpretty
+          xcodebuild test -scheme StoryFlow -destination "platform=iOS Simulator,name=iPhone 13" | xcpretty
       - uses: codecov/codecov-action@v1
-  test-iOS-12:
-    runs-on: macOS-latest
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_10.3.app/Contents/Developer
-    steps:
-      - uses: actions/checkout@v1
-      - name: Run StoryFlow tests on iOS 12
-        run: |
-          set -eo pipefail
-          xcodebuild test -scheme StoryFlow -destination "platform=iOS Simulator,OS=12.4,name=iPhone 8" | xcpretty
-

--- a/Sources/StoryFlow/Flow/ImplicitFlow/ImplicitFlow.swift
+++ b/Sources/StoryFlow/Flow/ImplicitFlow/ImplicitFlow.swift
@@ -16,8 +16,16 @@ extension Flow {
     
     private static func destination(for output: ValueAndType) -> UIViewController? {
         let (value, type) = OutputTransform.apply(output)
-        
-        for inType in inputRequiringTypes where oneOf(inType._inputType, contains: type) {
+
+        let candidates = inputRequiringTypes.filter { oneOf($0._inputType, contains: type) }
+        let supers = candidates.map { class_getSuperclass($0 as! AnyClass) }
+
+        let remainingCandidates = candidates.filter { c in
+            let isSuper = supers.contains { s in s == (c as! AnyClass) }
+            return !isSuper
+        }
+
+        for inType in remainingCandidates {
             return inType._create(input: value)
         }
         

--- a/Sources/StoryFlow/Flow/ImplicitFlow/ImplicitFlow.swift
+++ b/Sources/StoryFlow/Flow/ImplicitFlow/ImplicitFlow.swift
@@ -18,10 +18,10 @@ extension Flow {
         let (value, type) = OutputTransform.apply(output)
 
         let candidates = inputRequiringTypes.filter { oneOf($0._inputType, contains: type) }
-        let supers = candidates.map { class_getSuperclass($0 as! AnyClass) }
+        let supers = candidates.compactMap { class_getSuperclass($0 as? AnyClass) }
 
         let remainingCandidates = candidates.filter { c in
-            let isSuper = supers.contains { s in s == (c as! AnyClass) }
+            let isSuper = supers.contains { s in s == (c as? AnyClass) }
             return !isSuper
         }
 


### PR DESCRIPTION
In case there are more than 1 desstination candidates, pick the child…-most one, by discarding any candidate that is a superclass of another candidate.

example: 
Generic inputRequiring class: `AClass`
Some feature specific class that inherits from generic: `FeatureAClass`

When producing "A"
 - Before: storyflow would init `AClass` 
 + After: storyflow will init `FeatureAClass`