### PR TITLE
expand produce customisation 

### DIFF
--- a/Sources/StoryFlow/Interfaces/Helpers/Testing.swift
+++ b/Sources/StoryFlow/Interfaces/Helpers/Testing.swift
@@ -11,22 +11,27 @@ extension InputRequiring where Self: UIViewController {
 
 extension OutputProducing where Self: UIViewController {
 
+    /// - Parameters:
+    ///   - produceStub: Closure that optionally overrides default produce behavior.
+    ///   When nil is returned default produce behaviour will not be triggered.
     public init(
         nibName: String? = nil,
         bundle: Bundle? = nil,
-        produce: @escaping (OutputType) -> OutputType?
+        produceStub: @escaping (OutputType) -> OutputType?
     ) {
         self.init(nibName: nibName, bundle: bundle)
-        produceStub = produce
+        self.produceStub = produceStub
     }
     
+    /// - Parameters:
+    ///   - produceStub: Closure that overrides default produce behavior.
     public init(
         nibName: String? = nil,
         bundle: Bundle? = nil,
-        produce: @escaping (OutputType) -> ()
+        produceStub: @escaping (OutputType) -> ()
     ) {
         self.init(nibName: nibName, bundle: bundle) {
-            produce($0)
+            produceStub($0)
             return nil
         }
     }
@@ -40,25 +45,30 @@ private var produceStubKey = 0
 
 extension InputRequiring where Self: UIViewController & OutputProducing {
 
+    /// - Parameters:
+    ///   - produceStub: Closure that optionally overrides default produce behavior.
+    ///   When nil is returned default produce behaviour will not be triggered.
     public init(
         nibName: String? = nil,
         bundle: Bundle? = nil,
         input: InputType,
-        produce: @escaping (OutputType) -> OutputType?
+        produceStub: @escaping (OutputType) -> OutputType?
     ) {
         self.init(nibName: nibName, bundle: bundle)
         self.input = input
-        self.produceStub = produce
+        self.produceStub = produceStub
     }
     
+    /// - Parameters:
+    ///   - produceStub: Closure that overrides default produce behavior.
     public init(
         nibName: String? = nil,
         bundle: Bundle? = nil,
         input: InputType,
-        produce: @escaping (OutputType) -> ()
+        produceStub: @escaping (OutputType) -> ()
     ) {
         self.init(nibName: nibName, bundle: bundle) {
-            produce($0)
+            produceStub($0)
             return nil
         }
     }

--- a/Sources/StoryFlow/Interfaces/Helpers/Testing.swift
+++ b/Sources/StoryFlow/Interfaces/Helpers/Testing.swift
@@ -71,6 +71,7 @@ extension InputRequiring where Self: UIViewController & OutputProducing {
             produceStub($0)
             return nil
         }
+        self.input = input
     }
     
 }

--- a/Sources/StoryFlow/Interfaces/Helpers/Testing.swift
+++ b/Sources/StoryFlow/Interfaces/Helpers/Testing.swift
@@ -11,12 +11,27 @@ extension InputRequiring where Self: UIViewController {
 
 extension OutputProducing where Self: UIViewController {
 
-    public init(nibName: String? = nil, bundle: Bundle? = nil, produce: @escaping (OutputType) -> ()) {
+    public init(
+        nibName: String? = nil,
+        bundle: Bundle? = nil,
+        produce: @escaping (OutputType) -> OutputType?
+    ) {
         self.init(nibName: nibName, bundle: bundle)
         produceStub = produce
     }
+    
+    public init(
+        nibName: String? = nil,
+        bundle: Bundle? = nil,
+        produce: @escaping (OutputType) -> ()
+    ) {
+        self.init(nibName: nibName, bundle: bundle) {
+            produce($0)
+            return nil
+        }
+    }
 
-    var produceStub: ((OutputType) -> ())? {
+    var produceStub: ((OutputType) -> OutputType?)? {
         get { return associated(with: &produceStubKey) }
         set { associate(newValue, with: &produceStubKey) }
     }
@@ -25,10 +40,27 @@ private var produceStubKey = 0
 
 extension InputRequiring where Self: UIViewController & OutputProducing {
 
-    public init(nibName: String? = nil, bundle: Bundle? = nil,
-                input: InputType, produce: @escaping (OutputType) -> ()) {
+    public init(
+        nibName: String? = nil,
+        bundle: Bundle? = nil,
+        input: InputType,
+        produce: @escaping (OutputType) -> OutputType?
+    ) {
         self.init(nibName: nibName, bundle: bundle)
         self.input = input
         self.produceStub = produce
     }
+    
+    public init(
+        nibName: String? = nil,
+        bundle: Bundle? = nil,
+        input: InputType,
+        produce: @escaping (OutputType) -> ()
+    ) {
+        self.init(nibName: nibName, bundle: bundle) {
+            produce($0)
+            return nil
+        }
+    }
+    
 }

--- a/Sources/StoryFlow/Interfaces/OuputProducing.swift
+++ b/Sources/StoryFlow/Interfaces/OuputProducing.swift
@@ -19,10 +19,17 @@ extension OutputProducing where Self: UIViewController {
      - Parameter output: The value being passed to next view controller.
      */
     public func produce(_ output: OutputType) {
-
-        if let produce = produceStub {
-            produce(output)
-        } else if let flow = flow {
+        if let produceStub {
+            if let customOutput = produceStub(output) {
+                _produce(customOutput)
+            }
+        } else {
+            _produce(output)
+        }
+    }
+    
+    private func _produce(_ output: OutputType) {
+        if let flow = flow {
             flow.proceed(with: output, from: self)
         } else {
             implicitFlow.proceed(with: output, from: self)

--- a/StoryFlowTests/TestabilityTests.swift
+++ b/StoryFlowTests/TestabilityTests.swift
@@ -25,7 +25,7 @@ class TestabilityTests: XCTestCase {
         class Vc: UIViewController, OutputProducing { typealias OutputType = T }
 
         var producedOutput: T!
-        let vc = Vc(produce: { producedOutput = $0 })
+        let vc = Vc(produceStub: { producedOutput = $0 })
 
         let output = T()
 
@@ -48,7 +48,7 @@ class TestabilityTests: XCTestCase {
         var producedOutput: T!
 
         // Act
-        let vc = Vc(input: value, produce: { producedOutput = $0 })
+        let vc = Vc(input: value, produceStub: { producedOutput = $0 })
         vc.produce(value)
 
         // Assert


### PR DESCRIPTION
Expand `produceStub` to allow it to return optional output type.
When nil is returned nothing happens.
When non-nil is returned default produce flow kicks off.